### PR TITLE
Use `location.protocol` vs. `location.pageProtocol`

### DIFF
--- a/lib/makeTwemojiRenderer.js
+++ b/lib/makeTwemojiRenderer.js
@@ -1,7 +1,7 @@
 var React = require('react'),
 	assign = require('lodash.assign')
 
-var pageProtocol = (typeof location === 'undefined') ? '' : ((location.pageProtocol === 'https:') ? 'https:' : 'http:')
+var pageProtocol = (typeof location === 'undefined') ? '' : ((location.protocol === 'https:') ? 'https:' : 'http:')
 
 var emojiStyle = {
 	height: '1em',


### PR DESCRIPTION
Fixes https://github.com/appfigures/react-easy-emoji/issues/1
