### PR TITLE
Update package.json peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "string-replace-to-array": "^1.0.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.0 || >=15.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.0.0",


### PR DESCRIPTION
Peer dependencies on package.json do not include React v17.

This PR updates peerDependencies to include any React version >=15.

```
$ npm i react-easy-emoji
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: client@0.1.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^0.14.0 || ^15.0.0 || ^16.0.0" from react-easy-emoji@1.4.0
npm ERR! node_modules/react-easy-emoji
npm ERR!   react-easy-emoji@"*" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```